### PR TITLE
Support for anyio backend options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,8 +1,7 @@
 import asyncclick as click
+import asyncclick._compat
 from pallets_sphinx_themes import get_version
 from pallets_sphinx_themes import ProjectLink
-
-import asyncclick._compat
 
 # compat until pallets-sphinx-themes is updated
 click._compat.text_type = str
@@ -55,4 +54,6 @@ html_show_sourcelink = False
 
 # LaTeX ----------------------------------------------------------------
 
-latex_documents = [(master_doc, f"AsyncClick-{version}.tex", html_title, author, "manual")]
+latex_documents = [
+    (master_doc, f"AsyncClick-{version}.tex", html_title, author, "manual")
+]

--- a/src/click/core.py
+++ b/src/click/core.py
@@ -1063,14 +1063,23 @@ class BaseCommand:
         rv = await shell_complete(self, ctx_args, prog_name, complete_var, instruction)
         _fast_exit(rv)
 
-    def __call__(self, *args, _anyio_backend=None, **kwargs):
+    def __call__(
+        self, *args, _anyio_backend=None, _anyio_backend_options=None, **kwargs
+    ):
         """Alias for :meth:`main`."""
         main = self.main
         if _anyio_backend is None:
             import asyncclick
 
             _anyio_backend = asyncclick.anyio_backend
-        return anyio.run(self._main, main, args, kwargs, backend=_anyio_backend)
+        return anyio.run(
+            self._main,
+            main,
+            args,
+            kwargs,
+            backend=_anyio_backend,
+            backend_options=_anyio_backend_options,
+        )
 
     async def _main(self, main, args, kwargs):
         return await main(*args, **kwargs)

--- a/src/click/decorators.py
+++ b/src/click/decorators.py
@@ -9,7 +9,7 @@ from .globals import get_current_context
 from .utils import echo
 
 
-def async_backend(backend):
+def async_backend(backend, backend_options=None):
     """Selects the `anyio` backend to use.
 
     Valid choices are ``trio`` any ``asyncio``. The default is ``truo``.
@@ -22,6 +22,8 @@ def async_backend(backend):
         def new_func(*args, **kwargs):
             if "_anyio_backend" not in kwargs:
                 kwargs["_anyio_backend"] = backend
+            if "_anyio_backend_options" not in kwargs:
+                kwargs["_anyio_backend_options"] = backend_options
             return f(*args, **kwargs)
 
         return update_wrapper(new_func, f)


### PR DESCRIPTION
This allows to do things like enabled uvloop as follows:

```
import asyncclick as click
import uvloop
import asyncio


@click.command()
async def hello():
    if isinstance(asyncio.get_event_loop(), uvloop.Loop):
        click.echo("hello from uvloop")
    else:
        click.echo("hello from regular loop")

if __name__ == '__main__':
    hello(_anyio_backend="asyncio", _anyio_backend_options={"use_uvloop": True})
```