### PR TITLE
Update index.rst - Fix typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Welcome to the AsyncClick Documentation
     :scale: 50%
     :target: https://palletsprojects.com/p/click/
 
-AsyncClick ist a fork of Click that works well with (some) async
+AsyncClick is a fork of Click that works well with (some) async
 frameworks. Supported: asyncio, trio, and curio.
 
 Click, in turn, is a Python package for creating beautiful command line interfaces


### PR DESCRIPTION
I'm updating the Debian package and found this typo.

Similar reasoning to https://github.com/python-trio/asyncclick/pull/29

Thanks for your work on asyncclick!