### PR TITLE
tests: Fix conftest.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from click.testing import CliRunner
+from asyncclick.testing import CliRunner
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
This change fixes tests with Pytest collection:

```
Using pytest
ImportError while loading conftest '/tmp/guix-build-python-asyncclick-8.2.2.2.drv-0/asyncclick-8.2.2.2/tests/conftest.py'.
tests/conftest.py:3: in <module>
    from click.testing import CliRunner
E   ModuleNotFoundError: No module named 'click'
```
Ref: https://github.com/python-trio/asyncclick/issues/36#issuecomment-3192787379

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
